### PR TITLE
feat: ESP32 AWS IoT MQTT + T-Display-S3 LCD migration

### DIFF
--- a/custom_components/aws_iot_mqtt.h
+++ b/custom_components/aws_iot_mqtt.h
@@ -1,0 +1,289 @@
+#pragma once
+
+#include "esphome.h"
+#include <WiFiClientSecure.h>
+#include <PubSubClient.h>
+
+extern "C" {
+#include "mbedtls/md.h"
+#include "mbedtls/base64.h"
+}
+
+#define FIRMWARE_VERSION "1.0.0"
+
+// Global pointer for access from ESPHome lambdas
+class AwsIotMqttComponent;
+AwsIotMqttComponent *global_aws_mqtt = nullptr;
+
+class AwsIotMqttComponent : public Component {
+ public:
+  // ===== Configuration (set from YAML lambda) =====
+  std::string host;
+  uint16_t port = 443;
+  std::string tenant_id;
+  std::string secret_key;
+  std::string nonce;
+  std::string auth_name;
+  std::string client_id;
+
+  // Topics to subscribe
+  std::vector<std::string> sub_topics;
+
+  // Text sensors for displaying received messages (matched by index with sub_topics)
+  std::vector<esphome::text_sensor::TextSensor *> topic_sensors;
+  esphome::text_sensor::TextSensor *status_sensor = nullptr;
+
+  // ===== Monitoring stats (exposed via getters for YAML sensors) =====
+  uint32_t reconnect_count_ = 0;
+  uint32_t total_messages_ = 0;
+  unsigned long longest_conn_ms_ = 0;
+  unsigned long shortest_conn_ms_ = ULONG_MAX;
+  unsigned long conn_start_ms_ = 0;  // millis() when current connection started
+
+  // ===== Internal state =====
+  WiFiClientSecure wifi_client_;
+  PubSubClient *mqtt_client_ = nullptr;
+  bool connected_ = false;
+  unsigned long last_reconnect_ = 0;
+  unsigned long reconnect_interval_ = 10000;  // 10s between reconnect attempts
+  bool time_synced_ = false;
+
+  float get_setup_priority() const override {
+    return setup_priority::AFTER_WIFI;
+  }
+
+  // Set global pointer early so template sensors can access stats
+  // even before setup() runs
+  AwsIotMqttComponent() { global_aws_mqtt = this; }
+
+  void setup() override {
+
+    // TLS with ALPN "mqtt" for AWS IoT port 443
+    static const char *alpn_protos[] = {"mqtt", nullptr};
+    wifi_client_.setAlpnProtocols(alpn_protos);
+    wifi_client_.setInsecure();  // Skip cert verification for now
+
+    mqtt_client_ = new PubSubClient(wifi_client_);
+    mqtt_client_->setServer(host.c_str(), port);
+    mqtt_client_->setBufferSize(1024);
+    mqtt_client_->setKeepAlive(60);
+    mqtt_client_->setCallback(
+        [this](char *topic, byte *payload, unsigned int length) {
+          on_message_(topic, payload, length);
+        });
+
+    // NTP time sync (UTC)
+    configTime(0, 0, "pool.ntp.org", "time.nist.gov");
+    ESP_LOGI("aws_mqtt", "Setup done. Host: %s:%d, FW: %s", host.c_str(), port, FIRMWARE_VERSION);
+    update_status_("Waiting for NTP...");
+  }
+
+  void loop() override {
+    if (WiFi.status() != WL_CONNECTED) return;
+
+    // Check NTP sync
+    if (!time_synced_) {
+      time_t now_t = ::time(nullptr);
+      if (now_t > 1700000000) {
+        time_synced_ = true;
+        ESP_LOGI("aws_mqtt", "NTP synced! time=%ld", (long)now_t);
+        update_status_("NTP synced, connecting...");
+      } else {
+        return;  // Wait for NTP
+      }
+    }
+
+    if (!mqtt_client_->connected()) {
+      if (connected_) {
+        // Just disconnected — record session duration
+        unsigned long session_ms = millis() - conn_start_ms_;
+        if (session_ms > longest_conn_ms_) longest_conn_ms_ = session_ms;
+        if (session_ms < shortest_conn_ms_) shortest_conn_ms_ = session_ms;
+        connected_ = false;
+        update_status_("Disconnected");
+        ESP_LOGW("aws_mqtt", "MQTT disconnected (session was %lu s)", session_ms / 1000);
+      }
+      unsigned long now = millis();
+      if (now - last_reconnect_ > reconnect_interval_) {
+        last_reconnect_ = now;
+        do_connect_();
+      }
+    } else {
+      if (!connected_) {
+        connected_ = true;
+        conn_start_ms_ = millis();
+        update_status_("Connected");
+      }
+      mqtt_client_->loop();
+    }
+  }
+
+  // ===== Public API =====
+  bool is_connected() { return connected_; }
+  const char *get_version() { return FIRMWARE_VERSION; }
+  uint32_t get_reconnect_count() { return reconnect_count_; }
+  uint32_t get_total_messages() { return total_messages_; }
+
+  // Current connection duration in seconds (0 if not connected)
+  unsigned long get_current_conn_secs() {
+    if (!connected_) return 0;
+    return (millis() - conn_start_ms_) / 1000;
+  }
+
+  // Longest connection duration in seconds
+  unsigned long get_longest_conn_secs() {
+    // Also consider current ongoing session
+    unsigned long current = 0;
+    if (connected_) {
+      current = millis() - conn_start_ms_;
+    }
+    unsigned long best = longest_conn_ms_;
+    if (current > best) best = current;
+    return best / 1000;
+  }
+
+  // Shortest connection duration in seconds
+  unsigned long get_shortest_conn_secs() {
+    if (shortest_conn_ms_ == ULONG_MAX) return 0;  // No completed sessions yet
+    return shortest_conn_ms_ / 1000;
+  }
+
+  // Get current time as formatted string (UTC+8 Taipei)
+  std::string get_current_time_str() {
+    time_t now_t = ::time(nullptr);
+    if (now_t < 1700000000) return "NTP not synced";
+    now_t += 8 * 3600;  // UTC+8
+    struct tm *tm_info = gmtime(&now_t);
+    char buf[32];
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm_info);
+    return std::string(buf);
+  }
+
+  // Get uptime as human-readable string
+  std::string get_uptime_str() {
+    unsigned long secs = millis() / 1000;
+    unsigned long days = secs / 86400;
+    secs %= 86400;
+    unsigned long hours = secs / 3600;
+    secs %= 3600;
+    unsigned long mins = secs / 60;
+    secs %= 60;
+    char buf[64];
+    if (days > 0) {
+      snprintf(buf, sizeof(buf), "%lud %luh %lum %lus", days, hours, mins, secs);
+    } else if (hours > 0) {
+      snprintf(buf, sizeof(buf), "%luh %lum %lus", hours, mins, secs);
+    } else {
+      snprintf(buf, sizeof(buf), "%lum %lus", mins, secs);
+    }
+    return std::string(buf);
+  }
+
+  // ===== System Resource Getters =====
+  uint32_t get_cpu_freq_mhz() { return ESP.getCpuFreqMHz(); }
+  uint32_t get_free_heap() { return ESP.getFreeHeap(); }
+  uint32_t get_total_heap() { return ESP.getHeapSize(); }
+  uint32_t get_min_free_heap() { return ESP.getMinFreeHeap(); }
+  float get_heap_usage_pct() {
+    uint32_t total = ESP.getHeapSize();
+    if (total == 0) return 0;
+    return 100.0f * (1.0f - (float)ESP.getFreeHeap() / (float)total);
+  }
+
+  // Subscribed topics list (formatted string for display)
+  std::string get_subscribed_topics_str() {
+    std::string result;
+    for (size_t i = 0; i < sub_topics.size(); i++) {
+      if (i > 0) result += " | ";
+      result += std::to_string(i + 1) + ". " + sub_topics[i];
+    }
+    return result.empty() ? "No topics" : result;
+  }
+
+  void publish(const std::string &topic, const std::string &payload) {
+    if (mqtt_client_ && mqtt_client_->connected()) {
+      mqtt_client_->publish(topic.c_str(), payload.c_str());
+      ESP_LOGI("aws_mqtt", "Published to %s: %s", topic.c_str(),
+               payload.c_str());
+    } else {
+      ESP_LOGW("aws_mqtt", "Cannot publish - not connected");
+    }
+  }
+
+ private:
+  void do_connect_() {
+    reconnect_count_++;
+
+    // Generate dynamic HMAC credentials
+    std::string username, password;
+    gen_credentials_(username, password);
+
+    ESP_LOGI("aws_mqtt", "Connecting to AWS IoT as '%s'... (attempt #%u)",
+             client_id.c_str(), reconnect_count_);
+
+    if (mqtt_client_->connect(client_id.c_str(), username.c_str(),
+                               password.c_str())) {
+      ESP_LOGI("aws_mqtt", "Connected to AWS IoT!");
+      for (auto &topic : sub_topics) {
+        mqtt_client_->subscribe(topic.c_str());
+        ESP_LOGI("aws_mqtt", "Subscribed: %s", topic.c_str());
+      }
+    } else {
+      int rc = mqtt_client_->state();
+      ESP_LOGW("aws_mqtt", "Connect failed, rc=%d", rc);
+      update_status_("Connect failed (rc=" + std::to_string(rc) + ")");
+    }
+  }
+
+  void gen_credentials_(std::string &username, std::string &password) {
+    time_t now_t = ::time(nullptr);
+    std::string ts_str = std::to_string((long)now_t);
+    std::string username_base =
+        tenant_id + "-" + ts_str + "-" + nonce;
+    username =
+        username_base + "?x-amz-customauthorizer-name=" + auth_name;
+
+    // HMAC-SHA256(secret_key, username_base)
+    uint8_t hmac_out[32];
+    mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
+    mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1);
+    mbedtls_md_hmac_starts(&ctx, (const uint8_t *)secret_key.c_str(),
+                           secret_key.length());
+    mbedtls_md_hmac_update(&ctx, (const uint8_t *)username_base.c_str(),
+                           username_base.length());
+    mbedtls_md_hmac_finish(&ctx, hmac_out);
+    mbedtls_md_free(&ctx);
+
+    // Base64 encode
+    unsigned char b64[64];
+    size_t olen = 0;
+    mbedtls_base64_encode(b64, sizeof(b64), &olen, hmac_out, 32);
+    password = std::string((char *)b64, olen);
+
+    ESP_LOGD("aws_mqtt", "Generated creds - ts=%s, user_base=%s",
+             ts_str.c_str(), username_base.c_str());
+  }
+
+  void on_message_(char *topic, byte *payload, unsigned int length) {
+    std::string msg((char *)payload, length);
+    std::string topic_str(topic);
+    total_messages_++;
+    ESP_LOGI("aws_mqtt", "Received [%s]: %s (total: %u)", topic, msg.c_str(), total_messages_);
+
+    // Match topic to sensor
+    for (size_t i = 0; i < sub_topics.size() && i < topic_sensors.size();
+         i++) {
+      if (topic_str == sub_topics[i] && topic_sensors[i]) {
+        topic_sensors[i]->publish_state(msg);
+        break;
+      }
+    }
+  }
+
+  void update_status_(const std::string &status) {
+    if (status_sensor) {
+      status_sensor->publish_state(status);
+    }
+  }
+};

--- a/esp32-blink.yaml
+++ b/esp32-blink.yaml
@@ -1,0 +1,369 @@
+esphome:
+  name: esp32-blink
+  friendly_name: esp32-blink
+  on_boot:
+    priority: -100
+    then:
+      - light.turn_on:
+          id: rgb_led
+          brightness: 80%
+          effect: "Rainbow Cycle"
+  # Include custom AWS IoT MQTT component
+  includes:
+    - custom_components/aws_iot_mqtt.h
+  platformio_options:
+    lib_deps:
+      - "knolleary/PubSubClient@^2.8"
+    build_flags:
+      - "-I/Users/f/.platformio/packages/framework-arduinoespressif32/libraries/WiFiClientSecure/src"
+      - "-I/Users/f/.platformio/packages/framework-arduinoespressif32/libraries/WiFi/src"
+    lib_ldf_mode: chain+
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: "ivQPuuo8P+YDwS4c+v97viAyw6LtRIwbFcZ1YhhMJvs="
+
+ota:
+  password: "23d3086768ccc952505ee431922a3732"
+
+# WiFi configuration
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # AP mode - WiFi hotspot
+  ap:
+    ssid: "ESP32-Blink-AP"
+    password: "12345678"
+
+# Captive portal for WiFi configuration
+captive_portal:
+
+# Web Server - provides web UI for control
+web_server:
+  port: 80
+  auth:
+    username: admin
+    password: "123456"
+
+# NTP Time Sync (required for HMAC timestamp)
+time:
+  - platform: sntp
+    id: sntp_time
+    servers:
+      - "pool.ntp.org"
+      - "time.nist.gov"
+
+# ============================================
+# Custom AWS IoT MQTT Component
+# (replaces built-in mqtt: which doesn't support ALPN)
+# ============================================
+custom_component:
+  - lambda: |-
+      auto aws_mqtt = new AwsIotMqttComponent();
+      aws_mqtt->host = "a1lzjxzwzlrsek-ats.iot.ap-southeast-1.amazonaws.com";
+      aws_mqtt->port = 443;
+      aws_mqtt->tenant_id = "3b346aa6affad553b2395b86ee4f9d1d";
+      aws_mqtt->secret_key = "123456";
+      aws_mqtt->nonce = "localtest";
+      aws_mqtt->auth_name = "ygl-test-third";
+      aws_mqtt->client_id = "esp32-blink-001";
+      aws_mqtt->sub_topics = {
+        "ygl/device/status/3b346aa6affad553b2395b86ee4f9d1f/SW-L-01223"
+      };
+      aws_mqtt->topic_sensors = {id(mqtt_topic1_value)};
+      aws_mqtt->status_sensor = id(mqtt_status_text);
+      return {aws_mqtt};
+
+# ============================================
+# Text Sensors - display on Web UI
+# ============================================
+text_sensor:
+  # --- System Info ---
+  - platform: template
+    name: "Firmware Version"
+    id: firmware_version
+    icon: "mdi:tag"
+    lambda: |-
+      if (global_aws_mqtt) return std::string(global_aws_mqtt->get_version());
+      return std::string("N/A");
+    update_interval: 60s
+
+  - platform: template
+    name: "Current Time (UTC+8)"
+    id: current_time_text
+    icon: "mdi:clock-outline"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->get_current_time_str();
+      return std::string("N/A");
+    update_interval: 5s
+
+  - platform: template
+    name: "System Uptime"
+    id: uptime_text
+    icon: "mdi:timer-sand"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->get_uptime_str();
+      return std::string("N/A");
+    update_interval: 5s
+
+  # --- MQTT Status ---
+  - platform: template
+    name: "MQTT Status"
+    id: mqtt_status_text
+    icon: "mdi:cloud-check"
+
+  - platform: template
+    name: "Subscribed Topics"
+    id: subscribed_topics_list
+    icon: "mdi:format-list-bulleted"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->get_subscribed_topics_str();
+      return std::string("N/A");
+    update_interval: 60s
+
+  # --- MQTT Topic Messages (last received) ---
+  - platform: template
+    name: "Topic 1: device/status"
+    id: mqtt_topic1_value
+    icon: "mdi:message-text"
+
+  # --- WiFi Info ---
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+    ssid:
+      name: "Connected SSID"
+    mac_address:
+      name: "MAC Address"
+
+# ============================================
+# Sensors - numeric monitoring stats
+# ============================================
+sensor:
+  # --- System Resources ---
+  - platform: template
+    name: "CPU Frequency"
+    id: cpu_freq
+    icon: "mdi:chip"
+    accuracy_decimals: 0
+    unit_of_measurement: "MHz"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_cpu_freq_mhz();
+      return 0.0f;
+    update_interval: 30s
+
+  - platform: template
+    name: "Heap Usage"
+    id: heap_usage
+    icon: "mdi:memory"
+    accuracy_decimals: 1
+    unit_of_measurement: "%"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->get_heap_usage_pct();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "Free Heap"
+    id: free_heap
+    icon: "mdi:memory"
+    accuracy_decimals: 0
+    unit_of_measurement: "bytes"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_free_heap();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "Min Free Heap"
+    id: min_free_heap
+    icon: "mdi:alert-octagon"
+    accuracy_decimals: 0
+    unit_of_measurement: "bytes"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_min_free_heap();
+      return 0.0f;
+    update_interval: 10s
+
+  # --- WiFi ---
+  - platform: wifi_signal
+    name: "WiFi Signal"
+    update_interval: 30s
+
+  # --- MQTT Stats ---
+  - platform: template
+    name: "MQTT Reconnect Count"
+    id: mqtt_reconnect_count
+    icon: "mdi:refresh"
+    accuracy_decimals: 0
+    unit_of_measurement: "times"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_reconnect_count();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "MQTT Messages Received"
+    id: mqtt_total_messages
+    icon: "mdi:email-receive"
+    accuracy_decimals: 0
+    unit_of_measurement: "msgs"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_total_messages();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "Current Session Duration"
+    id: mqtt_current_conn
+    icon: "mdi:connection"
+    accuracy_decimals: 0
+    unit_of_measurement: "s"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_current_conn_secs();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "Longest Connection"
+    id: mqtt_longest_conn
+    icon: "mdi:arrow-up-bold"
+    accuracy_decimals: 0
+    unit_of_measurement: "s"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_longest_conn_secs();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "Shortest Connection"
+    id: mqtt_shortest_conn
+    icon: "mdi:arrow-down-bold"
+    accuracy_decimals: 0
+    unit_of_measurement: "s"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_shortest_conn_secs();
+      return 0.0f;
+    update_interval: 10s
+
+# ============================================
+# WS2812 RGB LED on GPIO48
+# ============================================
+light:
+  - platform: neopixelbus
+    name: "RGB LED"
+    id: rgb_led
+    type: GRB
+    variant: WS2812
+    pin: GPIO48
+    num_leds: 1
+    method:
+      type: esp32_rmt
+      channel: 0
+    default_transition_length: 1s
+    effects:
+      - random:
+          name: "Rainbow Cycle"
+          transition_length: 2s
+          update_interval: 3s
+      - pulse:
+          name: "Pulse"
+          transition_length: 1s
+          update_interval: 1s
+      - strobe:
+          name: "Strobe"
+          colors:
+            - state: true
+              brightness: 100%
+              red: 100%
+              green: 0%
+              blue: 0%
+              duration: 500ms
+            - state: false
+              duration: 500ms
+            - state: true
+              brightness: 100%
+              red: 0%
+              green: 100%
+              blue: 0%
+              duration: 500ms
+            - state: false
+              duration: 500ms
+            - state: true
+              brightness: 100%
+              red: 0%
+              green: 0%
+              blue: 100%
+              duration: 500ms
+            - state: false
+              duration: 500ms
+      - strobe:
+          name: "Fast Flash"
+          colors:
+            - state: true
+              brightness: 100%
+              red: 100%
+              green: 100%
+              blue: 100%
+              duration: 100ms
+            - state: false
+              duration: 100ms
+
+# ============================================
+# Buttons
+# ============================================
+button:
+  - platform: restart
+    name: "Restart ESP32"
+
+  - platform: template
+    name: "MQTT Publish Test"
+    icon: "mdi:send"
+    on_press:
+      - lambda: |-
+          if (global_aws_mqtt) {
+            global_aws_mqtt->publish(
+              "ygl/device/status/3b346aa6affad553b2395b86ee4f9d1f/SW-L-01223",
+              "{\"device\":\"SW-L-01223\",\"status\":\"alive\"}");
+          }
+
+# ============================================
+# Switches
+# ============================================
+switch:
+  - platform: template
+    name: "MQTT Connected"
+    id: mqtt_connected_switch
+    icon: "mdi:cloud-sync"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->is_connected();
+      return false;
+    turn_on_action:
+      - logger.log: "MQTT is managed automatically"
+    turn_off_action:
+      - logger.log: "MQTT is managed automatically"
+
+# ============================================
+# Interval - update MQTT status periodically
+# ============================================
+interval:
+  - interval: 10s
+    then:
+      - lambda: |-
+          if (global_aws_mqtt) {
+            if (global_aws_mqtt->is_connected()) {
+              id(mqtt_status_text).publish_state("Connected");
+            } else {
+              id(mqtt_status_text).publish_state("Disconnected");
+            }
+          }

--- a/t-display-s3-mqtt.yaml
+++ b/t-display-s3-mqtt.yaml
@@ -1,0 +1,650 @@
+esphome:
+  name: t-display-s3-mqtt
+  friendly_name: T-Display-S3 MQTT
+  on_boot:
+    priority: -100
+    then:
+      - light.turn_on:
+          id: lcd_backlight
+          brightness: 80%
+  # Include custom AWS IoT MQTT component
+  includes:
+    - custom_components/aws_iot_mqtt.h
+  platformio_options:
+    lib_deps:
+      - "knolleary/PubSubClient@^2.8"
+    build_flags:
+      - "-I/Users/f/.platformio/packages/framework-arduinoespressif32/libraries/WiFiClientSecure/src"
+      - "-I/Users/f/.platformio/packages/framework-arduinoespressif32/libraries/WiFi/src"
+    lib_ldf_mode: chain+
+
+# T-Display-S3 display driver (local external component)
+external_components:
+  - source:
+      type: local
+      path: tdisplays3
+    components: [tdisplays3]
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  framework:
+    type: arduino
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: "ivQPuuo8P+YDwS4c+v97viAyw6LtRIwbFcZ1YhhMJvs="
+
+ota:
+  password: "23d3086768ccc952505ee431922a3732"
+
+# WiFi configuration
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # AP mode fallback
+  ap:
+    ssid: "T-Display-S3-AP"
+    password: "12345678"
+
+# Captive portal for WiFi configuration
+captive_portal:
+
+# Web Server - provides web UI for control
+web_server:
+  port: 80
+  auth:
+    username: admin
+    password: "123456"
+
+# NTP Time Sync (required for HMAC timestamp)
+time:
+  - platform: sntp
+    id: sntp_time
+    servers:
+      - "pool.ntp.org"
+      - "time.nist.gov"
+
+# ============================================
+# Backlight Output (GPIO38 PWM)
+# ============================================
+output:
+  - platform: ledc
+    pin: GPIO38
+    id: backlight_pwm
+    frequency: 2000
+
+light:
+  - platform: monochromatic
+    output: backlight_pwm
+    name: "5.HW - LCD Backlight"
+    id: lcd_backlight
+    restore_mode: RESTORE_DEFAULT_ON
+
+# ============================================
+# Fonts for LCD Display
+# ============================================
+font:
+  - file: "gfonts://Roboto"
+    id: font_title
+    size: 18
+
+  - file: "gfonts://Roboto"
+    id: font_body
+    size: 14
+
+  - file: "gfonts://Roboto Mono"
+    id: font_value
+    size: 13
+
+  - file: "gfonts://Roboto"
+    id: font_small
+    size: 10
+
+# ============================================
+# Globals for page tracking
+# ============================================
+globals:
+  - id: current_page
+    type: int
+    initial_value: "0"
+
+# ============================================
+# LCD Display - T-Display-S3 (320x170 landscape)
+# ============================================
+display:
+  - platform: tdisplays3
+    id: my_display
+    update_interval: 2s
+    rotation: 270
+    pages:
+      # ---- Page 1: System Overview ----
+      - id: page_system
+        lambda: |-
+          int w = it.get_width();   // 320
+          int h = it.get_height();  // 170
+
+          // Title bar background
+          it.filled_rectangle(0, 0, w, 22, Color(0, 40, 80));
+          it.printf(4, 3, id(font_title), Color(255, 255, 255), "SYSTEM OVERVIEW");
+
+          // MQTT status dot
+          if (global_aws_mqtt && global_aws_mqtt->is_connected()) {
+            it.filled_circle(w - 30, 11, 5, Color(0, 200, 0));
+          } else {
+            it.filled_circle(w - 30, 11, 5, Color(200, 0, 0));
+          }
+          it.printf(w - 4, 5, id(font_small), Color(180, 180, 180), TextAlign::TOP_RIGHT, "1/4");
+
+          // Content
+          int y = 28;
+          int lh = 22;  // line height
+          auto white = Color(255, 255, 255);
+          auto gray = Color(160, 160, 160);
+          auto cyan = Color(0, 210, 210);
+
+          it.printf(4, y, id(font_body), gray, "FW Version:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%s",
+              id(firmware_version).state.c_str());
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "Time:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%s",
+              id(current_time_text).state.c_str());
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "Uptime:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%s",
+              id(uptime_text).state.c_str());
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "WiFi:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%s (%.0f dBm)",
+              id(wifi_ssid_info).state.c_str(), id(wifi_signal_sensor).state);
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "IP:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%s",
+              id(ip_address_info).state.c_str());
+
+          // Bottom nav
+          it.filled_rectangle(0, h - 16, w, 16, Color(30, 30, 30));
+          it.printf(4, h - 14, id(font_small), Color(100, 100, 100), "< Prev");
+          it.printf(w / 2, h - 14, id(font_small), Color(140, 140, 140), TextAlign::TOP_CENTER, "[1/4]");
+          it.printf(w - 4, h - 14, id(font_small), Color(100, 100, 100), TextAlign::TOP_RIGHT, "Next >");
+
+      # ---- Page 2: MQTT Status ----
+      - id: page_mqtt
+        lambda: |-
+          int w = it.get_width();
+          int h = it.get_height();
+
+          it.filled_rectangle(0, 0, w, 22, Color(0, 60, 40));
+          it.printf(4, 3, id(font_title), Color(255, 255, 255), "MQTT STATUS");
+
+          if (global_aws_mqtt && global_aws_mqtt->is_connected()) {
+            it.filled_circle(w - 30, 11, 5, Color(0, 200, 0));
+          } else {
+            it.filled_circle(w - 30, 11, 5, Color(200, 0, 0));
+          }
+          it.printf(w - 4, 5, id(font_small), Color(180, 180, 180), TextAlign::TOP_RIGHT, "2/4");
+
+          int y = 28;
+          int lh = 21;
+          auto gray = Color(160, 160, 160);
+          auto cyan = Color(0, 210, 210);
+          auto green = Color(0, 220, 80);
+          auto red = Color(220, 60, 60);
+
+          it.printf(4, y, id(font_body), gray, "Status:");
+          if (global_aws_mqtt && global_aws_mqtt->is_connected()) {
+            it.printf(w - 4, y, id(font_value), green, TextAlign::TOP_RIGHT, "Connected");
+          } else {
+            it.printf(w - 4, y, id(font_value), red, TextAlign::TOP_RIGHT, "Disconnected");
+          }
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "Reconnects:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f",
+              id(mqtt_reconnect_count).state);
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "Session:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f s",
+              id(mqtt_current_conn).state);
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "Longest:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f s",
+              id(mqtt_longest_conn).state);
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "Shortest:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f s",
+              id(mqtt_shortest_conn).state);
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "Messages:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f",
+              id(mqtt_total_messages).state);
+
+          // Bottom nav
+          it.filled_rectangle(0, h - 16, w, 16, Color(30, 30, 30));
+          it.printf(4, h - 14, id(font_small), Color(100, 100, 100), "< Prev");
+          it.printf(w / 2, h - 14, id(font_small), Color(140, 140, 140), TextAlign::TOP_CENTER, "[2/4]");
+          it.printf(w - 4, h - 14, id(font_small), Color(100, 100, 100), TextAlign::TOP_RIGHT, "Next >");
+
+      # ---- Page 3: System Resources ----
+      - id: page_resources
+        lambda: |-
+          int w = it.get_width();
+          int h = it.get_height();
+
+          it.filled_rectangle(0, 0, w, 22, Color(60, 30, 0));
+          it.printf(4, 3, id(font_title), Color(255, 255, 255), "SYSTEM RESOURCES");
+
+          if (global_aws_mqtt && global_aws_mqtt->is_connected()) {
+            it.filled_circle(w - 30, 11, 5, Color(0, 200, 0));
+          } else {
+            it.filled_circle(w - 30, 11, 5, Color(200, 0, 0));
+          }
+          it.printf(w - 4, 5, id(font_small), Color(180, 180, 180), TextAlign::TOP_RIGHT, "3/4");
+
+          int y = 28;
+          int lh = 22;
+          auto gray = Color(160, 160, 160);
+          auto cyan = Color(0, 210, 210);
+
+          it.printf(4, y, id(font_body), gray, "CPU Freq:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f MHz",
+              id(cpu_freq).state);
+          y += lh;
+
+          // Heap usage with progress bar
+          float heap_pct = id(heap_usage).state;
+          it.printf(4, y, id(font_body), gray, "Heap Used:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.1f%%", heap_pct);
+          y += lh - 2;
+
+          // Progress bar
+          int bar_x = 4;
+          int bar_w = w - 8;
+          int bar_h = 8;
+          it.rectangle(bar_x, y, bar_w, bar_h, gray);
+          int fill_w = (int)(bar_w * heap_pct / 100.0f);
+          if (fill_w > bar_w) fill_w = bar_w;
+          auto bar_color = heap_pct > 80 ? Color(220, 60, 60) : heap_pct > 60 ? Color(220, 180, 0) : Color(0, 200, 80);
+          it.filled_rectangle(bar_x + 1, y + 1, fill_w - 2, bar_h - 2, bar_color);
+          y += bar_h + 6;
+
+          it.printf(4, y, id(font_body), gray, "Free Heap:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f bytes",
+              id(free_heap).state);
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "Min Heap:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f bytes",
+              id(min_free_heap).state);
+          y += lh;
+
+          it.printf(4, y, id(font_body), gray, "WiFi Signal:");
+          it.printf(w - 4, y, id(font_value), cyan, TextAlign::TOP_RIGHT, "%.0f dBm",
+              id(wifi_signal_sensor).state);
+
+          // Bottom nav
+          it.filled_rectangle(0, h - 16, w, 16, Color(30, 30, 30));
+          it.printf(4, h - 14, id(font_small), Color(100, 100, 100), "< Prev");
+          it.printf(w / 2, h - 14, id(font_small), Color(140, 140, 140), TextAlign::TOP_CENTER, "[3/4]");
+          it.printf(w - 4, h - 14, id(font_small), Color(100, 100, 100), TextAlign::TOP_RIGHT, "Next >");
+
+      # ---- Page 4: MQTT Messages ----
+      - id: page_messages
+        lambda: |-
+          int w = it.get_width();
+          int h = it.get_height();
+
+          it.filled_rectangle(0, 0, w, 22, Color(50, 0, 60));
+          it.printf(4, 3, id(font_title), Color(255, 255, 255), "MQTT MESSAGES");
+
+          if (global_aws_mqtt && global_aws_mqtt->is_connected()) {
+            it.filled_circle(w - 30, 11, 5, Color(0, 200, 0));
+          } else {
+            it.filled_circle(w - 30, 11, 5, Color(200, 0, 0));
+          }
+          it.printf(w - 4, 5, id(font_small), Color(180, 180, 180), TextAlign::TOP_RIGHT, "4/4");
+
+          int y = 28;
+          auto gray = Color(160, 160, 160);
+          auto cyan = Color(0, 210, 210);
+          auto yellow = Color(220, 200, 0);
+
+          it.printf(4, y, id(font_body), gray, "Subscribed Topics:");
+          y += 18;
+          it.printf(8, y, id(font_small), cyan, "%s",
+              id(subscribed_topics_list).state.c_str());
+          y += 18;
+
+          // Separator line
+          it.line(4, y, w - 4, y, Color(60, 60, 60));
+          y += 6;
+
+          it.printf(4, y, id(font_body), gray, "Last Message:");
+          y += 18;
+
+          // Show message content, truncated to fit
+          std::string msg = id(mqtt_topic1_value).state;
+          if (msg.length() > 0) {
+            // Show up to 3 lines of message content
+            int max_chars = 42;  // approx chars per line with font_small
+            for (int line = 0; line < 3 && !msg.empty(); line++) {
+              std::string chunk;
+              if ((int)msg.length() <= max_chars) {
+                chunk = msg;
+                msg = "";
+              } else {
+                chunk = msg.substr(0, max_chars);
+                msg = msg.substr(max_chars);
+              }
+              it.printf(8, y, id(font_small), yellow, "%s", chunk.c_str());
+              y += 14;
+            }
+            if (!msg.empty()) {
+              it.printf(8, y, id(font_small), Color(100, 100, 100), "...(truncated)");
+            }
+          } else {
+            it.printf(8, y, id(font_small), Color(100, 100, 100), "No messages yet");
+          }
+
+          // Bottom nav
+          it.filled_rectangle(0, h - 16, w, 16, Color(30, 30, 30));
+          it.printf(4, h - 14, id(font_small), Color(100, 100, 100), "< Prev");
+          it.printf(w / 2, h - 14, id(font_small), Color(140, 140, 140), TextAlign::TOP_CENTER, "[4/4]");
+          it.printf(w - 4, h - 14, id(font_small), Color(100, 100, 100), TextAlign::TOP_RIGHT, "Next >");
+
+# ============================================
+# Button Navigation (Left = Prev, Right = Next)
+# ============================================
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO0
+      mode: INPUT_PULLUP
+      inverted: true
+    name: "Left Button"
+    id: btn_left
+    on_press:
+      then:
+        - display.page.show_previous: my_display
+        - component.update: my_display
+
+  - platform: gpio
+    pin:
+      number: GPIO14
+      mode: INPUT_PULLUP
+      inverted: true
+    name: "Right Button"
+    id: btn_right
+    on_press:
+      then:
+        - display.page.show_next: my_display
+        - component.update: my_display
+
+# ============================================
+# Custom AWS IoT MQTT Component
+# ============================================
+custom_component:
+  - lambda: |-
+      auto aws_mqtt = new AwsIotMqttComponent();
+      aws_mqtt->host = "a1lzjxzwzlrsek-ats.iot.ap-southeast-1.amazonaws.com";
+      aws_mqtt->port = 443;
+      aws_mqtt->tenant_id = "3b346aa6affad553b2395b86ee4f9d1d";
+      aws_mqtt->secret_key = "123456";
+      aws_mqtt->nonce = "localtest";
+      aws_mqtt->auth_name = "ygl-test-third";
+      aws_mqtt->client_id = "t-display-s3-001";
+      aws_mqtt->sub_topics = {
+        "ygl/device/status/3b346aa6affad553b2395b86ee4f9d1f/SW-L-01223"
+      };
+      aws_mqtt->topic_sensors = {id(mqtt_topic1_value)};
+      aws_mqtt->status_sensor = id(mqtt_status_text);
+      return {aws_mqtt};
+
+# ============================================
+# Text Sensors
+# ============================================
+text_sensor:
+  # --- 1. System Info ---
+  - platform: template
+    name: "1.System - Firmware Version"
+    id: firmware_version
+    icon: "mdi:tag"
+    lambda: |-
+      if (global_aws_mqtt) return std::string(global_aws_mqtt->get_version());
+      return std::string("N/A");
+    update_interval: 60s
+
+  - platform: template
+    name: "1.System - Current Time (UTC+8)"
+    id: current_time_text
+    icon: "mdi:clock-outline"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->get_current_time_str();
+      return std::string("N/A");
+    update_interval: 5s
+
+  - platform: template
+    name: "1.System - Uptime"
+    id: uptime_text
+    icon: "mdi:timer-sand"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->get_uptime_str();
+      return std::string("N/A");
+    update_interval: 5s
+
+  # --- 2. MQTT ---
+  - platform: template
+    name: "2.MQTT - Status"
+    id: mqtt_status_text
+    icon: "mdi:cloud-check"
+
+  - platform: template
+    name: "2.MQTT - Subscribed Topics"
+    id: subscribed_topics_list
+    icon: "mdi:format-list-bulleted"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->get_subscribed_topics_str();
+      return std::string("N/A");
+    update_interval: 60s
+
+  # --- 4. Messages ---
+  - platform: template
+    name: "4.Msg - Topic 1: device/status"
+    id: mqtt_topic1_value
+    icon: "mdi:message-text"
+
+  # --- 1. System - WiFi Info ---
+  - platform: wifi_info
+    ip_address:
+      name: "1.System - IP Address"
+      id: ip_address_info
+    ssid:
+      name: "1.System - WiFi SSID"
+      id: wifi_ssid_info
+    mac_address:
+      name: "1.System - MAC Address"
+
+# ============================================
+# Sensors - numeric monitoring stats
+# ============================================
+sensor:
+  # --- 3. Resources ---
+  - platform: template
+    name: "3.Resources - CPU Frequency"
+    id: cpu_freq
+    icon: "mdi:chip"
+    accuracy_decimals: 0
+    unit_of_measurement: "MHz"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_cpu_freq_mhz();
+      return 0.0f;
+    update_interval: 30s
+
+  - platform: template
+    name: "3.Resources - Heap Usage"
+    id: heap_usage
+    icon: "mdi:memory"
+    accuracy_decimals: 1
+    unit_of_measurement: "%"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->get_heap_usage_pct();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "3.Resources - Free Heap"
+    id: free_heap
+    icon: "mdi:memory"
+    accuracy_decimals: 0
+    unit_of_measurement: "bytes"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_free_heap();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "3.Resources - Min Free Heap"
+    id: min_free_heap
+    icon: "mdi:alert-octagon"
+    accuracy_decimals: 0
+    unit_of_measurement: "bytes"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_min_free_heap();
+      return 0.0f;
+    update_interval: 10s
+
+  # --- 5. Hardware ---
+  - platform: wifi_signal
+    name: "5.HW - WiFi Signal"
+    id: wifi_signal_sensor
+    update_interval: 30s
+
+  - platform: adc
+    pin: GPIO4
+    name: "5.HW - Battery Voltage"
+    id: battery_voltage
+    unit_of_measurement: "V"
+    accuracy_decimals: 2
+    attenuation: auto
+    update_interval: 30s
+    filters:
+      - multiply: 2.0
+
+  # --- 2. MQTT Stats ---
+  - platform: template
+    name: "2.MQTT - Reconnect Count"
+    id: mqtt_reconnect_count
+    icon: "mdi:refresh"
+    accuracy_decimals: 0
+    unit_of_measurement: "times"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_reconnect_count();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "2.MQTT - Messages Received"
+    id: mqtt_total_messages
+    icon: "mdi:email-receive"
+    accuracy_decimals: 0
+    unit_of_measurement: "msgs"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_total_messages();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "2.MQTT - Current Session"
+    id: mqtt_current_conn
+    icon: "mdi:connection"
+    accuracy_decimals: 0
+    unit_of_measurement: "s"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_current_conn_secs();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "2.MQTT - Longest Connection"
+    id: mqtt_longest_conn
+    icon: "mdi:arrow-up-bold"
+    accuracy_decimals: 0
+    unit_of_measurement: "s"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_longest_conn_secs();
+      return 0.0f;
+    update_interval: 10s
+
+  - platform: template
+    name: "2.MQTT - Shortest Connection"
+    id: mqtt_shortest_conn
+    icon: "mdi:arrow-down-bold"
+    accuracy_decimals: 0
+    unit_of_measurement: "s"
+    lambda: |-
+      if (global_aws_mqtt) return (float)global_aws_mqtt->get_shortest_conn_secs();
+      return 0.0f;
+    update_interval: 10s
+
+# ============================================
+# Buttons
+# ============================================
+button:
+  - platform: restart
+    name: "1.System - Restart"
+
+  - platform: template
+    name: "2.MQTT - Publish Test"
+    icon: "mdi:send"
+    on_press:
+      - lambda: |-
+          if (global_aws_mqtt) {
+            global_aws_mqtt->publish(
+              "ygl/device/status/3b346aa6affad553b2395b86ee4f9d1f/SW-L-01223",
+              "{\"device\":\"SW-L-01223\",\"status\":\"alive\"}");
+          }
+
+# ============================================
+# Switches
+# ============================================
+switch:
+  - platform: template
+    name: "2.MQTT - Connected"
+    id: mqtt_connected_switch
+    icon: "mdi:cloud-sync"
+    lambda: |-
+      if (global_aws_mqtt) return global_aws_mqtt->is_connected();
+      return false;
+    turn_on_action:
+      - logger.log: "MQTT is managed automatically"
+    turn_off_action:
+      - logger.log: "MQTT is managed automatically"
+
+# ============================================
+# Interval - update MQTT status periodically
+# ============================================
+interval:
+  - interval: 10s
+    then:
+      - lambda: |-
+          if (global_aws_mqtt) {
+            if (global_aws_mqtt->is_connected()) {
+              id(mqtt_status_text).publish_state("Connected");
+            } else {
+              id(mqtt_status_text).publish_state("Disconnected");
+            }
+          }

--- a/tdisplays3/__init__.py
+++ b/tdisplays3/__init__.py
@@ -1,0 +1,5 @@
+import esphome.codegen as cg
+
+dependencies = ["display"]
+
+tdisplays3_ns = cg.esphome_ns.namespace("tdisplays3")

--- a/tdisplays3/display.py
+++ b/tdisplays3/display.py
@@ -1,0 +1,71 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import display
+from esphome.const import (
+  CONF_HEIGHT,
+  CONF_ID,
+  CONF_LAMBDA,
+  CONF_WIDTH,
+)
+from . import tdisplays3_ns
+
+TDISPLAYS3 = tdisplays3_ns.class_(
+    "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
+)
+
+def validate_tdisplays3(config):
+   return config
+
+CONFIG_SCHEMA = cv.All(
+    display.FULL_DISPLAY_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(TDISPLAYS3),
+            cv.Optional(CONF_HEIGHT): cv.int_,
+            cv.Optional(CONF_WIDTH): cv.int_,
+        }
+    ).extend(cv.polling_component_schema("5s")),
+    validate_tdisplays3,
+)
+
+async def to_code(config):
+    # Add platformio build_flags for the correct TFT_eSPI settings for the T-Display-S3
+    # This allows using current, unpatched versions of TFT_eSPI
+    cg.add_build_flag("-DUSER_SETUP_LOADED=1")
+    cg.add_build_flag("-DST7789_DRIVER")
+    cg.add_build_flag("-DINIT_SEQUENCE_3")
+    cg.add_build_flag("-DCGRAM_OFFSET")
+    cg.add_build_flag("-DTFT_RGB_ORDER=TFT_RGB")
+    cg.add_build_flag("-DTFT_INVERSION_ON")
+    cg.add_build_flag("-DTFT_PARALLEL_8_BIT")
+    cg.add_build_flag("-DTFT_WIDTH=170")
+    cg.add_build_flag("-DTFT_HEIGHT=320")
+    cg.add_build_flag("-DTFT_DC=7")
+    cg.add_build_flag("-DTFT_RST=5")
+    cg.add_build_flag("-DTFT_WR=8")
+    cg.add_build_flag("-DTFT_RD=9")
+    cg.add_build_flag("-DTFT_D0=39")
+    cg.add_build_flag("-DTFT_D1=40")
+    cg.add_build_flag("-DTFT_D2=41")
+    cg.add_build_flag("-DTFT_D3=42")
+    cg.add_build_flag("-DTFT_D4=45")
+    cg.add_build_flag("-DTFT_D5=46")
+    cg.add_build_flag("-DTFT_D6=47")
+    cg.add_build_flag("-DTFT_D7=48")
+    # If you don't care about control of the backlight you can uncomment the two lines below")
+    #cg.add_build_flag("-DTFT_BL=38")
+    #cg.add_build_flag("-DTFT_BACKLIGHT_ON=HIGH")
+
+    cg.add_library("SPI", None)
+    cg.add_library("FS", None)
+    cg.add_library("SPIFFS", None)
+    cg.add_library("TFT_eSPI", None)
+
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await display.register_display(var, config)
+
+    if CONF_LAMBDA in config:
+        lambda_ = await cg.process_lambda(
+            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+        )
+        cg.add(var.set_writer(lambda_))

--- a/tdisplays3/t_display_s3.h
+++ b/tdisplays3/t_display_s3.h
@@ -1,0 +1,69 @@
+#ifndef TDISPLAY_S3
+#define TDISPLAY_S3
+
+#include "TFT_eSPI.h"
+#include "esphome.h"
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/components/display/display_buffer.h"
+#include "esphome/components/display/display_color_utils.h"
+
+namespace esphome {
+namespace tdisplays3 {
+
+static const char *const TAG = "TDisplayS3";
+
+class TDisplayS3 : public PollingComponent,
+                   public display::DisplayBuffer
+{
+  public:
+    void setup() override {
+        tft.init();
+        spr.createSprite(get_width_internal(), get_height_internal());
+        tft.fillScreen(TFT_BLACK);
+    }
+
+    void loop() override {
+    }
+
+    //////////
+    // DisplayBuffer methods
+    //////////
+    void fill(Color color) override {
+        spr.fillScreen(display::ColorUtil::color_to_565(color));
+    }
+
+    int get_width_internal() override {
+        return tft.getViewportWidth();
+    }
+
+    int get_height_internal() override {
+	return tft.getViewportHeight();
+    }
+
+    display::DisplayType get_display_type() override {
+        return display::DisplayType::DISPLAY_TYPE_COLOR;
+    }
+
+    void draw_absolute_pixel_internal(int x, int y, Color color) override {
+        spr.drawPixel(x, y, display::ColorUtil::color_to_565(color));
+    }
+
+    /////////////
+    // PollingComponent Methods
+    /////////////
+    void update() override {
+        this->do_update_();
+        spr.pushSprite(0, 0);
+    }
+
+  private:
+    TFT_eSPI tft = TFT_eSPI();
+    TFT_eSprite spr = TFT_eSprite(&tft);
+};
+
+}  // namespace tdisplays3
+}  // namespace esphome
+
+#endif

--- a/tdisplays3/touchscreen/__init__.py
+++ b/tdisplays3/touchscreen/__init__.py
@@ -1,0 +1,50 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+
+from esphome import pins
+from esphome.components import i2c, touchscreen
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN, CONF_RESET_PIN
+
+from .. import tdisplays3_ns
+
+DEPENDENCIES = ["i2c"]
+
+LilygoTDisplayS3Touchscreen = tdisplays3_ns.class_(
+    "LilygoTDisplayS3Touchscreen",
+    touchscreen.Touchscreen,
+    cg.Component,
+    i2c.I2CDevice,
+)
+
+CONF_LILYGO_TDISPLAY_S3_TOUCHSCREEN_ID = "lilygo_tdisplay_s3_touchscreen_id"
+CONF_OFFSET_X = "x_offset"
+CONF_OFFSET_Y = "y_offset"
+
+CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(LilygoTDisplayS3Touchscreen),
+            cv.Required(CONF_INTERRUPT_PIN): cv.All(
+                pins.internal_gpio_input_pin_schema
+            ),
+            cv.Optional(CONF_OFFSET_X): cv.int_,
+            cv.Optional(CONF_OFFSET_Y): cv.int_,
+        }
+    )
+    .extend(i2c.i2c_device_schema(0x15))
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+    await touchscreen.register_touchscreen(var, config)
+
+    interrupt_pin = await cg.gpio_pin_expression(config[CONF_INTERRUPT_PIN])
+    x_offset = config.get(CONF_OFFSET_X, 0)
+    y_offset = config.get(CONF_OFFSET_Y, 0)
+
+    cg.add(var.set_interrupt_pin(interrupt_pin))
+    cg.add(var.set_offset(x_offset, y_offset));

--- a/tdisplays3/touchscreen/t_display_s3_touchscreen.cpp
+++ b/tdisplays3/touchscreen/t_display_s3_touchscreen.cpp
@@ -1,0 +1,136 @@
+#include "t_display_s3_touchscreen.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace tdisplays3 {
+
+using namespace touchscreen;
+
+static const char *const TAG = "lilygo_tdisplay_s3.touchscreen";
+
+static const uint8_t POWER_REGISTER = 0xD6;
+static const uint8_t WORK_MODE_REGISTER = 0x00;
+
+static const uint8_t TOUCH_NUM_INDEX = 0x02;
+static const uint8_t TOUCH1_XH_INDEX = 0x03;
+static const uint8_t TOUCH1_XL_INDEX = 0x04;
+static const uint8_t TOUCH1_YH_INDEX = 0x05;
+static const uint8_t TOUCH1_YL_INDEX = 0x06;
+static const uint8_t FIRMWARE_LOW_INDEX = 0xA6;
+static const uint8_t FIRMWARE_HIGH_INDEX = 0xA7;
+
+static const uint8_t WAKEUP_CMD[1] = {0x06};
+
+#define ERROR_CHECK(err) \
+  if ((err) != i2c::ERROR_OK) { \
+    ESP_LOGE(TAG, "Failed to communicate!"); \
+    this->status_set_warning(); \
+    return; \
+  }
+
+int16_t combine_h4l8(uint8_t high, uint8_t low) { return (high & 0x0F) << 8 | low; }
+
+void Store::gpio_intr(Store *store) { store->touch = true; }
+
+void LilygoTDisplayS3Touchscreen::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up Lilygo T-Display S3 Touchscreen...");
+  this->interrupt_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+  this->interrupt_pin_->setup();
+
+  this->store_.pin = this->interrupt_pin_->to_isr();
+  this->interrupt_pin_->attach_interrupt(Store::gpio_intr, &this->store_, gpio::INTERRUPT_FALLING_EDGE);
+
+  this->write_register(POWER_REGISTER, WAKEUP_CMD, 1);
+
+  uint8_t buffer[40] = {0};
+
+  i2c::ErrorCode err;
+  err = this->read_register(WORK_MODE_REGISTER, buffer, sizeof(buffer));
+  ERROR_CHECK(err);
+
+  this->firmware_version_ = buffer[FIRMWARE_HIGH_INDEX] << 8 & buffer[FIRMWARE_LOW_INDEX];
+}
+
+void LilygoTDisplayS3Touchscreen::loop() {
+  if (!this->store_.touch) {
+    for (auto *listener : this->touch_listeners_)
+      listener->release();
+    return;
+  }
+  this->store_.touch = false;
+
+  uint8_t point = 0;
+  uint8_t buffer[40] = {0};
+  uint32_t sum_l = 0, sum_h = 0;
+
+  i2c::ErrorCode err;
+  err = this->read_register(WORK_MODE_REGISTER, buffer, sizeof(buffer));
+  ERROR_CHECK(err);
+
+  if (buffer[TOUCH_NUM_INDEX] == 0) {
+    ESP_LOGV(TAG, "touch released");
+  }
+
+  point = buffer[TOUCH_NUM_INDEX] & 0x0f;
+
+  TouchPoint tp;
+  tp.id = point;
+  int16_t x;
+  int16_t y;
+
+  uint8_t xh = buffer[TOUCH1_XH_INDEX];
+  uint8_t xl = buffer[TOUCH1_XL_INDEX];
+  uint8_t yh = buffer[TOUCH1_YH_INDEX];
+  uint8_t yl = buffer[TOUCH1_YL_INDEX];
+
+  tp.state = xh >> 6;
+  x = combine_h4l8(xh, xl);
+  y = combine_h4l8(yh, yl);
+
+  switch (this->rotation_) {
+    default:
+    case ROTATE_0_DEGREES:
+      tp.y = y;
+      tp.x = x;
+      break;
+    case ROTATE_90_DEGREES:
+      tp.x = y;
+      tp.y = this->display_width_ - x;
+      break;
+    case ROTATE_180_DEGREES:
+      tp.y = this->display_height_ - y;
+      tp.x = this->display_width_ - x;
+      break;
+    case ROTATE_270_DEGREES:
+      tp.x = this->display_height_ - y;
+      tp.y = x;
+      break;
+  }
+  tp.x += this->x_offset_;
+  tp.y += this->y_offset_;
+
+  this->x=tp.x;
+  this->y=tp.y;
+  if (point == 0) {
+     ESP_LOGV(TAG, "Touch detected at (%d, %d). State: %d", tp.x, tp.y, tp.state);
+     this->defer([this, tp]() { this->send_touch_(tp); });
+  } else {
+    for (auto *listener : this->touch_listeners_)
+      listener->release();
+  }
+
+  this->status_clear_warning();
+}
+
+void LilygoTDisplayS3Touchscreen::dump_config() {
+  ESP_LOGCONFIG(TAG, "Lilygo T-Display S3 Touchscreen:");
+  LOG_I2C_DEVICE(this);
+  LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
+  ESP_LOGCONFIG(TAG, "  Rotation: %d", this->rotation_);
+  ESP_LOGCONFIG(TAG, "  Offset: (%d, %d)", this->x_offset_, this->y_offset_);
+  ESP_LOGCONFIG(TAG, "  Firmware version: %d", this->firmware_version_);
+}
+
+}  // namespace tdisplays3
+}  // namespace esphome

--- a/tdisplays3/touchscreen/t_display_s3_touchscreen.h
+++ b/tdisplays3/touchscreen/t_display_s3_touchscreen.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/touchscreen/touchscreen.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace tdisplays3 {
+
+/**
+ * Store interrupt related information.
+ */
+struct Store {
+  volatile bool touch;
+  ISRInternalGPIOPin pin;
+
+  static void gpio_intr(Store *store);
+};
+
+class LilygoTDisplayS3Touchscreen : public touchscreen::Touchscreen, public Component, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+  void set_offset(int16_t x_offset, int16_t y_offset) { x_offset_ = x_offset; y_offset_ = y_offset; }
+
+  int16_t x;
+  int16_t y;
+
+ protected:
+  InternalGPIOPin *interrupt_pin_;
+  int16_t x_offset_;
+  int16_t y_offset_;
+  uint16_t firmware_version_;
+  Store store_;
+
+};
+
+}  // namespace lilygo_tdisplay_s3
+}  // namespace esphome


### PR DESCRIPTION
## Summary
- **ESP32-S3 DevKitC-1 config** (`esp32-blink.yaml`): AWS IoT MQTT custom component with HMAC-SHA256 auth, WS2812 RGB LED, web UI with full monitoring dashboard (CPU, heap, WiFi, MQTT stats)
- **T-Display-S3 migration** (`t-display-s3-mqtt.yaml`): Ports the entire project to LilyGO T-Display-S3 board with 1.9" ST7789V LCD, 4-page paginated display (System Overview, MQTT Status, Resources, Messages), button navigation (GPIO0=prev, GPIO14=next), and organized web UI with numbered group prefixes
- **Custom MQTT component** (`aws_iot_mqtt.h`): WiFiClientSecure + PubSubClient with ALPN "mqtt" on port 443 for AWS IoT Custom Authorizer, dynamic HMAC-SHA256 credential generation via mbedtls
- **Display driver** (`tdisplays3/`): Local external component using TFT_eSPI for 8-bit parallel interface

## Test plan
- [ ] Compile `t-display-s3-mqtt.yaml` with ESPHome
- [ ] Flash to LilyGO T-Display-S3 via USB
- [ ] Verify LCD displays Page 1 (System Overview) on boot
- [ ] Test button navigation (left=prev, right=next) through all 4 pages
- [ ] Verify AWS IoT MQTT connection via serial logs
- [ ] Check web UI at `http://<ip>/` shows organized sensor groups
- [ ] Confirm MQTT messages appear on Page 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)